### PR TITLE
Updated $netsuite instance var to match examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $config = array(
    "log_path" => "/var/www/myapp/logs/netsuite"
 );
 
-$netsuite = new NetSuiteService($config);
+$service = new NetSuiteService($config);
 ```
 
 #### Retreiving a customer record:


### PR DESCRIPTION
NetSuiteService setup you $netsuite is used as the service instance variable.

Other examples use $service, updated the setup part to be compatible with other examples.