### PR TITLE
Pull in es02's changes with a few extra modifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+## General Settings
+NETSUITE_ENDPOINT="2019_1"
+NETSUITE_HOST="https://webservices.netsuite.com"
+NETSUITE_ACCOUNT="MYACCT1"
+NETSUITE_APPID="AF44ECC6-6691-400C-85A2-9FD7BFABE36E" # Credential Based Auth
+
+## Credential Based Auth Settings
+NETSUITE_EMAIL="jDoe@netsuite.com"
+NETSUITE_PASSWORD="mySecretPwd"
+NETSUITE_ROLE="1"
+
+## Token Based Auth Settings
+NETSUITE_HASH_TYPE="sha256"
+# Integration Keys
+NETSUITE_CONSUMER_KEY=""
+NETSUITE_CONSUMER_SECRET=""
+# Access Token Keys
+NETSUITE_TOKEN_KEY=""
+NETSUITE_TOKEN_SECRET=""

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ use NetSuite\NetSuiteService;
 
 $config = array(
    // required -------------------------------------
-   "endpoint" => "2017_1",
+   "endpoint" => "2019_1",
    "host"     => "https://webservices.netsuite.com",
    "email"    => "jDoe@netsuite.com",
    "password" => "mySecretPwd",
@@ -48,6 +48,18 @@ $config = array(
 );
 
 $service = new NetSuiteService($config);
+```
+
+You can alternatively place your config in environment variables.
+This is helpful in hosted environments where deployment of config files is either not desired or practical.
+You can find the required key/value pairs in the included .env.example file.
+
+```php
+require 'vendor/autoload.php';
+
+use NetSuite\NetSuiteService;
+
+$service = new NetSuiteService();
 ```
 
 ## Account-Specific Data Center URLs

--- a/README.md
+++ b/README.md
@@ -50,9 +50,15 @@ $config = array(
 $service = new NetSuiteService($config);
 ```
 
-You can alternatively place your config in environment variables.
-This is helpful in hosted environments where deployment of config files is either not desired or practical.
-You can find the required key/value pairs in the included .env.example file.
+You can alternatively place your config in environment variables. This is
+helpful in hosted environments where deployment of config files is either
+not desired or practical. You can find the valid keys in the included
+.env.example file with sample values.
+
+Previously, instantiating the NetSuiteClient with ENV data entailed using the
+static method `createFromEnv`. This method is now marked as `deprecated` and
+if you are using it, please change your code to use the standard constructor
+which will extract your configuration out of the $_ENV superglobal for you.
 
 ```php
 require 'vendor/autoload.php';
@@ -328,6 +334,7 @@ $service = new NetSuiteService($config);
  - [x] Logging
  - [x] Dynamic Data Center URLs
  - [x] Expanded user documentation
+ - [x] Support automagic configuration via ENV variables
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Instead of instantiating `NetSuiteService` with the standard credentials method,
 ```php
 $config = array(
    // required -------------------------------------
-   "endpoint"       => "2017_1",
+   "endpoint"       => "2019_1",
    "host"           => "https://webservices.netsuite.com",
    "account"        => "MYACCT1",
    "consumerKey"    => "0123456789ABCDEF",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "suggest": {
         "vlucas/phpdotenv": "Provides loading a .env file for obtaining config variables",
-        "symfony/dotenv": "Provides loading a .env file for obtaining config variables",
+        "symfony/dotenv": "Provides loading a .env file for obtaining config variables"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,10 @@
   "require-dev": {
     "phpspec/phpspec": "^2.4"
   },
+  "suggest": {
+        "vlucas/phpdotenv": "Provides loading a .env file for obtaining config variables",
+        "symfony/dotenv": "Provides loading a .env file for obtaining config variables",
+  },
   "autoload": {
     "psr-4": {
       "NetSuite\\": "src/"

--- a/src/NetSuiteClient.php
+++ b/src/NetSuiteClient.php
@@ -91,12 +91,23 @@ class NetSuiteClient
             'app_id'             => getenv('NETSUITE_APP_ID') ?: '4AD027CA-88B3-46EC-9D3E-41C6E6A325E2',
             'logging'            => getenv('NETSUITE_LOGGING'),
             'log_path'           => getenv('NETSUITE_LOG_PATH'),
-            'consumerKey'        => getenv('NETSUITE_CONSUMER_KEY'),
-            'consumerSecret'     => getenv('NETSUITE_CONSUMER_SECRET'),
-            'token'              => getenv('NETSUITE_TOKEN_KEY'),
-            'tokenSecret'        => getenv('NETSUITE_TOKEN_SECRET'),
-            'signatureAlgorithm' => getenv('NETSUITE_HASHTYPE') ?: 'sha256',
         ];
+
+        // These config keys aren't required by all users, but if they are
+        // defined in the config array, then they must be correct, thus we
+        // will omit ones that have been left empty in the .env file.
+        $optKeys = [
+            'NETSUITE_CONSUMER_KEY'    => 'consumerKey',
+            'NETSUITE_CONSUMER_SECRET' => 'consumerSecret',
+            'NETSUITE_TOKEN_KEY'       => 'token',
+            'NETSUITE_TOKEN_SECRET'    => 'tokenSecret',
+            'NETSUITE_HASH_TYPE'       => 'signatureAlgorithm'
+        ];
+        foreach ($optKeys as $optKey => $cfgKey) {
+            if ($optVal = getenv($optKey)) {
+                $config[$cfgKey] = $optVal;
+            }
+        }
 
         return $config;
     }


### PR DESCRIPTION
From es01:
* Expand/update config options
* Add `.env.example` to show available keys
* Add suggested configuration packages

Additionally:
* Set `2019_1` to the new default endpoint
* Readme updates
* Removed config file loading code from client instantiation method(s)
* Add basic config validation method
* Restore original `createFromEnv` static method functionality