### PR TITLE
Only create logger once

### DIFF
--- a/src/NetSuiteClient.php
+++ b/src/NetSuiteClient.php
@@ -37,6 +37,10 @@ class NetSuiteClient
      * @var array
      */
     private $soapHeaders = array();
+    /**
+     * @var \NetSuite\Logger
+     */
+    private $logger;
 
     /**
      * @param array $config
@@ -59,6 +63,10 @@ class NetSuiteClient
             // provided the legacy webservices URL.
             $this->setDataCenterUrl($config);
         }
+        $this->logger = new Logger(
+            isset($this->config['log_path']) ? $this->config['log_path'] : NULL
+        );
+
     }
 
     /**
@@ -391,6 +399,7 @@ class NetSuiteClient
     public function setLogPath($logPath)
     {
         $this->config['log_path'] = $logPath;
+        $this->logger = new Logger($logPath);
     }
 
     /**
@@ -401,10 +410,7 @@ class NetSuiteClient
     private function logSoapCall($operation)
     {
         if (isset($this->config['logging']) && $this->config['logging']) {
-            $logger = new Logger(
-                isset($this->config['log_path']) ? $this->config['log_path'] : null
-            );
-            $logger->logSoapCall($this->client, $operation);
+            $this->logger->logSoapCall($this->client, $operation);
         }
     }
 


### PR DESCRIPTION
PHP 7 is quite a bit faster than 5 when creating objects and compared to a soap request I'm sure the cost isn't even measurable but its a lot cheaper to only create the log class once in the constructor and reusing it. This would also be a first step toward supporting something like PSR-3 by moving the creation to the constructor it would be easy to follow to allow injecting or replacing your own log class.

The setLogPath method kinda throws a kink in things but I expect it doesn't get called very often so its easy enough to recreate the Logger for now.