### PR TITLE
Add type hinting to exported classes

### DIFF
--- a/utilities/includes/ClassSeparator.php
+++ b/utilities/includes/ClassSeparator.php
@@ -207,7 +207,7 @@ class ClassSeparator
             }
             // Add a doc comment for each property.
             foreach ($types as $variable_name => $property_type) {
-                $class = preg_replace('/public \$' . $variable_name . '/', "/**\n     * @var $property_type\n     */\n    public \$$variable_name", $class);
+                $class = preg_replace('/public \$' . $variable_name . ';/', "/**\n     * @var $property_type\n     */\n    public \$$variable_name;", $class);
             }
             // Template write the class.
             $filename = base_path() . '/src/Classes/' . $name . '.php';


### PR DESCRIPTION
Using this library has been great but navigating objects is also pretty time consuming and PHPStorm can't really help me out with completions because the classes from NetSuite don't have any hints so its been kinda slow trying to prototype and experiment with different services and having to dig through the object explorer and opening every class file.

The basic idea was that `$paramtypesmap` generally holds a definition of the types for each property of the class. This isn't actually useful to any IDE's though so it just sits there and you have to read each class to find out the properties. Most IDE's can read phpdoc style variable definitions though and provide inspection and completion based on it. So if we can take those definitions and convert them its a big developer experience win.

To do this, I used php's tokenizer to parse the class definition into a structured format we can look at. Then it digs through until it find the magic property, translates that into real types, and writes it back into the class string.

This ends up with a class that looks something like this:
```
class AsyncUpsertListRequest {
    /**
     * @var \NetSuite\Classes\Record[]
     */
    public $record;
    static $paramtypesmap = array(
        "record" => "Record[]",
    );
}
```

This is approach is very functional and should be pretty bullet proof and fast since the php tokenizer is very quick. However it is also _really_ ugly so let me know if there are any changes. So far copying them modified classes over to a project has made navigating the objects a _lot_ easier so I hope you like it. :-D
